### PR TITLE
HelperModule.psm1 - local Import-Module to use Join-Path

### DIFF
--- a/Extension/task/HelperModule.psm1
+++ b/Extension/task/HelperModule.psm1
@@ -46,7 +46,7 @@ function Import-Pester {
             }
             catch {
                 Write-Host "##vso[task.logissue type=warning]Falling back to version of Pester shipped with extension. To use a newer version please update the version of PowerShellGet available on this machine."
-                Import-Module "$PSScriptRoot\4.10.1\Pester.psd1" -force -Verbose:$false
+                Import-Module -Name (Join-Path $PSScriptRoot "4.10.1\Pester.psd1") -Force -Verbose:$false
             }
         }
 
@@ -67,7 +67,7 @@ function Import-Pester {
     }
     else {
         Write-Host "##vso[task.logissue type=warning]Falling back to version of Pester shipped with extension. To use a newer version please update the version of PowerShellGet available on this machine."
-        Import-Module "$PSScriptRoot\4.10.1\Pester.psd1" -Force -Verbose:$false
+        Import-Module -Name (Join-Path $PSScriptRoot "4.10.1\Pester.psd1") -Force -Verbose:$false
     }
 
 }

--- a/Extension/task/task.json
+++ b/Extension/task/task.json
@@ -2,7 +2,7 @@
   "id": "cca5462b-887d-4617-bf3f-dcf0d3c622e9",
   "name": "Pester",
   "friendlyName": "Pester Test Runner",
-  "description": "Run Pester tests by either installing the latest version of Pester at run time (if possible) or using the version shipped with the task (4.6.0)",
+  "description": "Run Pester tests by either installing the latest version of Pester at run time (if possible) or using the version shipped with the task (4.10.1)",
   "helpMarkDown": "Version: #{Build.BuildNumber}#. [More Information](https://github.com/pester/AzureDevOpsExtension)",
   "category": "Test",
   "visibility": [


### PR DESCRIPTION
### What problem does this PR address?
Updates the HelperModule.psm1 local Import-Module calls to use Join-Path the same that Pester.ps1 Imports HelperModule.psm1
Also, updates task description for shipped version of Pester
  
### Is there a related Issue?
[Issue #16 - Pester Test Runner does not fall back to shipped Pester version](https://github.com/pester/AzureDevOpsExtension/issues/16)
  
### Have you...
- If you are willing, please enable me, as the Repo owner, to [edit your fork that contains your PR](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) so I can add any missing items such as the readme.md
