### PR TITLE
Add passthru to ensure pester results are output - fixes #28

### DIFF
--- a/Extension/PesterTask/PesterV10/Pester.ps1
+++ b/Extension/PesterTask/PesterV10/Pester.ps1
@@ -92,6 +92,7 @@ $PesterConfig = @{
     Run = @{
         Path = $TestFolder
         Exit = $true
+        PassThrue = $true
     }
     TestResult = @{
         Enabled = $true
@@ -142,6 +143,6 @@ if (-not([String]::IsNullOrWhiteSpace($ScriptBlock))) {
 
 $result = Invoke-Pester -Configuration  ([PesterConfiguration]$PesterConfig)
 
-if ($result.failedCount -ne 0) {
+if ($result.failedCount -gt 0) {
     Write-Error "Pester returned errors"
 }

--- a/Extension/PesterTask/PesterV10/Pester.ps1
+++ b/Extension/PesterTask/PesterV10/Pester.ps1
@@ -91,8 +91,7 @@ $PesterConfig = @{
 
     Run = @{
         Path = $TestFolder
-        Exit = $true
-        PassThrue = $true
+        PassThru = $true
     }
     TestResult = @{
         Enabled = $true
@@ -143,6 +142,6 @@ if (-not([String]::IsNullOrWhiteSpace($ScriptBlock))) {
 
 $result = Invoke-Pester -Configuration  ([PesterConfiguration]$PesterConfig)
 
-if ($result.failedCount -gt 0) {
-    Write-Error "Pester returned errors"
+if ($Result.FailedCount -gt 0) {
+    Write-Error "Pester Failed at least one test. Please see results for details."
 }

--- a/pester-v10.yml
+++ b/pester-v10.yml
@@ -17,6 +17,7 @@ steps:
 
   - task: PublishTestResults@2
     displayName: 'Publish Test Results Test-Pester.XML'
+    condition: 'always()'
     inputs:
       testRunTitle: '$(agent.os)-v10'
       testResultsFormat: NUnit
@@ -24,6 +25,7 @@ steps:
     
   - task: PublishCodeCoverageResults@1
     displayName: 'Publish code coverage'
+    condition: 'always()'
     inputs:
       summaryFileLocation: '$(System.DefaultWorkingDirectory)/CC-Pester.XML'
   

--- a/pester-v9.yml
+++ b/pester-v9.yml
@@ -17,6 +17,7 @@ steps:
 
   - task: PublishTestResults@2
     displayName: 'Publish Test Results Test-Pester.XML'
+    condition: 'always()'
     inputs:
       testRunTitle: '$(agent.os)-v9'
       testResultsFormat: NUnit
@@ -24,6 +25,7 @@ steps:
     
   - task: PublishCodeCoverageResults@1
     displayName: 'Publish code coverage'
+    condition: 'always()'
     inputs:
       summaryFileLocation: '$(System.DefaultWorkingDirectory)/CC-Pester.XML'
   

--- a/testResults.xml
+++ b/testResults.xml
@@ -1,0 +1,29 @@
+﻿<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<test-results xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="nunit_schema_2.5.xsd" name="Pester" total="6" errors="0" failures="1" not-run="0" inconclusive="0" ignored="0" skipped="0" invalid="0" date="2020-06-07" time="17:19:09">
+  <environment platform="Microsoft Windows 10 Enterprise|C:\WINDOWS|\Device\Harddisk0\Partition4" os-version="10.0.19041" nunit-version="2.5.8.0" machine-name="DESKTOP-T1JUALL" cwd="C:\source\github\PesterAzureDevOpsExtension" user-domain="DESKTOP-T1JUALL" clr-version="Unknown" user="Chris" />
+  <culture-info current-culture="en-GB" current-uiculture="en-GB" />
+  <test-suite type="TestFixture" name="Pester" executed="True" result="Failure" success="False" time="0.1278" asserts="0" description="Pester">
+    <results>
+      <test-suite type="TestFixture" name="C:\source\github\PesterAzureDevOpsExtension\Extension\tests\Calculator\Add-Numbers.Tests.ps1" executed="True" result="Failure" success="False" time="0.1278" asserts="0" description="C:\source\github\PesterAzureDevOpsExtension\Extension\tests\Calculator\Add-Numbers.Tests.ps1">
+        <results>
+          <test-suite type="TestFixture" name="Add-Numbers" executed="True" result="Failure" success="False" time="0.1126" asserts="0" description="Add-Numbers">
+            <results>
+              <test-case description="adds positive numbers" name="Add-Numbers.adds positive numbers" time="0.0027" asserts="0" success="True" result="Success" executed="True" />
+              <test-case description="adds negative numbers" name="Add-Numbers.adds negative numbers" time="0.0057" asserts="0" success="True" result="Success" executed="True" />
+              <test-case description="adds one negative number to positive number" name="Add-Numbers.adds one negative number to positive number" time="0.0029" asserts="0" success="True" result="Success" executed="True" />
+              <test-case description="concatenates strings if given strings" name="Add-Numbers.concatenates strings if given strings" time="0.0085" asserts="0" success="True" result="Success" executed="True" />
+              <test-case description="should not be 0" name="Add-Numbers.should not be 0" time="0.003" asserts="0" success="True" result="Success" executed="True" />
+              <test-case description="Should fail" name="Add-Numbers.Should fail" time="0.0235" asserts="0" success="False" result="Failure" executed="True">
+                <failure>
+                  <message>Expected $false, but got $true.
+at $true | Should -Be $false, C:\source\github\PesterAzureDevOpsExtension\Extension\tests\Calculator\Add-Numbers.Tests.ps1:28</message>
+                  <stack-trace>at &lt;ScriptBlock&gt;, C:\source\github\PesterAzureDevOpsExtension\Extension\tests\Calculator\Add-Numbers.Tests.ps1:28</stack-trace>
+                </failure>
+              </test-case>
+            </results>
+          </test-suite>
+        </results>
+      </test-suite>
+    </results>
+  </test-suite>
+</test-results>


### PR DESCRIPTION
### What problem does this PR address?
v10 wasn't using passthru due to the changes in the configuration object. This adds it back in to ensure the output is returned and usable.
  
### Is there a related Issue?
#28 