### PR TITLE
Suppress error messages when Powershell Gallery isn't reachable - fixes #18 

### DIFF
--- a/Extension/PesterTask/test/PesterTask/Helper.Tests.ps1
+++ b/Extension/PesterTask/test/PesterTask/Helper.Tests.ps1
@@ -2,7 +2,7 @@
 Describe "Testing Helper Functions" {
 
     BeforeAll {
-        Import-Module -Name (Resolve-Path "$PSScriptRoot/../../task/HelperModule.psm1") -Force
+        Import-Module -Name (Resolve-Path "$PSScriptRoot/../../PesterV9/HelperModule.psm1") -Forc
     }
     Context "Testing Get-HashtableFromString" {
 
@@ -82,103 +82,105 @@ Describe "Testing Helper Functions" {
         }
     }
 
-    Context "Testing Import-Pester" {
+    InModuleScope "HelperModule" {
+        Context "Testing Import-Pester" {
 
-        BeforeAll {
-            Mock -CommandName Import-Module -MockWith { }
-            Mock -CommandName Install-Module -MockWith { $true }
-            Mock -CommandName Write-host -MockWith { }
-            Mock -CommandName Get-PSRepository -MockWith {[PSCustomObject]@{Name = 'PSGallery'}}
-            Mock -CommandName Get-Command -MockWith { [PsCustomObject]@{Parameters=@{SkipPublisherCheck='SomeValue'}}} -ParameterFilter {$Name -eq 'Install-Module'}
-            Mock -CommandName Get-Command -MockWith { [PsCustomObject]@{Parameters=@{AllowPrerelease='SomeValue'}}} -ParameterFilter {$Name -eq 'Find-Module'}
-        }
-
-        It "Installs the latest version of Pester when on PS5+ and PowerShellGet is available" {
-            Mock -CommandName Find-Module -MockWith { [PsCustomObject]@{Version=[version]::new(9,9,9);Repository='PSGallery'}}
-            Mock -CommandName Get-PackageProvider -MockWith { $True }
-
-            Import-Pester -Version "latest"
-            
-            Assert-MockCalled -CommandName Import-Module -ParameterFilter {$RequiredVersion -eq "9.9.9"} -Scope It -Times 1
-        }
-
-        It "Installs the latest version of Pester from PSGallery when multiple repositories are available" {
-            Mock -CommandName Find-Module -MockWith { @(
-                    [PsCustomObject]@{Version=[version]::new(4,3,0);Repository='OtherRepository'}
-                    [PsCustomObject]@{Version=[version]::new(9,9,9);Repository='PSGallery'}
-                )
+            BeforeAll {
+                Mock -CommandName Import-Module -MockWith { }
+                Mock -CommandName Install-Module -MockWith { $true }
+                Mock -CommandName Write-host -MockWith { }
+                Mock -CommandName Get-PSRepository -MockWith {[PSCustomObject]@{Name = 'PSGallery'}}
+                Mock -CommandName Get-Command -MockWith { [PsCustomObject]@{Parameters=@{SkipPublisherCheck='SomeValue'}}} -ParameterFilter {$Name -eq 'Install-Module'}
+                Mock -CommandName Get-Command -MockWith { [PsCustomObject]@{Parameters=@{AllowPrerelease='SomeValue'}}} -ParameterFilter {$Name -eq 'Find-Module'}
             }
-            Mock -CommandName Get-PackageProvider -MockWith { $True }
 
-            Import-Pester -Version "latest"
+            It "Installs the latest version of Pester when on PS5+ and PowerShellGet is available" {
+                Mock -CommandName Find-Module -MockWith { [PsCustomObject]@{Version=[version]::new(9,9,9);Repository='PSGallery'}}
+                Mock -CommandName Get-PackageProvider -MockWith { $True }
 
-            Assert-MockCalled -CommandName Install-Module -Scope It -ParameterFilter {$Repository -eq 'PSGallery'}
-        }
-
-        It "Installs the required version of NuGet provider when PowerShellGet is available and NuGet isn't already installed" {
-            Mock -CommandName Find-Module -MockWith { [PsCustomObject]@{Version=[version]::new(9,9,9);Repository='PSGallery'}}
-            Mock -CommandName Get-PackageProvider -MockWith { throw }
-            Mock -CommandName Install-PackageProvider -MockWith {}
-
-            Import-Pester -Version "latest"
-
-            Assert-MockCalled -CommandName Install-PackageProvider
-        }
-
-        It "Should not install a new version of Pester when the latest is already installed" {
-            Mock -CommandName Find-Module -MockWith { [PsCustomObject]@{Version=(Get-Module Pester).Version;Repository='PSGallery'}}
-            Mock -CommandName Get-PackageProvider -MockWith { $True }
-
-            Import-Pester -Version "latest"
-
-            Assert-MockCalled -CommandName Install-Module -Times 0 -Scope It
-        }
-
-        It "Should install and import the specified version of Pester regardless of what is avaialble locally" {
-            Mock -CommandName Find-Module -MockWith { [PsCustomObject]@{Version=[version]::new(4,2,0);Repository='PSGallery'}}
-            Mock -CommandName Get-PackageProvider -MockWith { $True }
-
-            Import-Pester -Version 4.2.0
-
-            Assert-MockCalled -CommandName Install-Module -Times 1 -ParameterFilter { $RequiredVersion -eq "4.2.0"}
-            Assert-MockCalled -CommandName Import-Module -Times 1 -ParameterFilter {$RequiredVersion -eq "4.2.0"}
-        }
-
-        It "Should not Install the latest version of Pester when on PowerShellGet is available but SkipPublisherCheck is not available" {
-            Mock -CommandName Find-Module -MockWith { [PsCustomObject]@{Version=[version]::new(9,9,9);Repository='PSGallery'}}
-            Mock -CommandName Get-PackageProvider -MockWith { $True }
-            Mock -CommandName Get-Command -MockWith { [PsCustomObject]@{Parameters=@{OtherProperty='SomeValue'}} } -ParameterFilter {$Name -eq 'Install-Module'}
-
-            Import-Pester -Version "latest"
-
-            Assert-MockCalled -CommandName Install-Module -Times 0 -Scope It
-            Assert-MockCalled -CommandName Import-Module -Times 1 -ParameterFilter {$Name -like '*\4.10.1\Pester.psd1'}
-        }
-
-        It "Should fall back to build in version of Pester when no repositories are available" {
-            Mock -CommandName Get-PSRepository -MockWith {}
-            Mock -CommandName Get-Command -MockWith { [PsCustomObject]@{Parameters=@{SkipPublisherCheck='SomeValue'}}} -ParameterFilter {$Name -eq 'Install-Module'}
-
-            Import-Pester -Version "latest"
-
-            Assert-MockCalled -CommandName Install-Module -Times 0 -Scope It
-            Assert-MockCalled -CommandName Write-Host -Times 1 -Scope It -ParameterFilter {
-                $Object -eq "##vso[task.logissue type=warning]Falling back to version of Pester shipped with extension. To use a newer version please update the version of PowerShellGet available on this machine."
+                Import-Pester -Version "latest"
+                
+                Assert-MockCalled -CommandName Import-Module -ParameterFilter {$RequiredVersion -eq "9.9.9"} -Scope It -Times 1
             }
-            Assert-MockCalled -CommandName Import-Module -Times 1 -ParameterFilter {$Name -like '*\4.10.1\Pester.psd1'}
+
+            It "Installs the latest version of Pester from PSGallery when multiple repositories are available" {
+                Mock -CommandName Find-Module -MockWith { @(
+                        [PsCustomObject]@{Version=[version]::new(4,3,0);Repository='OtherRepository'}
+                        [PsCustomObject]@{Version=[version]::new(9,9,9);Repository='PSGallery'}
+                    )
+                }
+                Mock -CommandName Get-PackageProvider -MockWith { $True }
+
+                Import-Pester -Version "latest"
+
+                Assert-MockCalled -CommandName Install-Module -Scope It -ParameterFilter {$Repository -eq 'PSGallery'}
+            }
+
+            It "Installs the required version of NuGet provider when PowerShellGet is available and NuGet isn't already installed" {
+                Mock -CommandName Find-Module -MockWith { [PsCustomObject]@{Version=[version]::new(9,9,9);Repository='PSGallery'}}
+                Mock -CommandName Get-PackageProvider -MockWith { throw }
+                Mock -CommandName Install-PackageProvider -MockWith {}
+
+                Import-Pester -Version "latest"
+
+                Assert-MockCalled -CommandName Install-PackageProvider
+            }
+
+            It "Should not install a new version of Pester when the latest is already installed" {
+                Mock -CommandName Find-Module -MockWith { [PsCustomObject]@{Version=(Get-Module Pester).Version;Repository='PSGallery'}}
+                Mock -CommandName Get-PackageProvider -MockWith { $True }
+
+                Import-Pester -Version "latest"
+
+                Assert-MockCalled -CommandName Install-Module -Times 0 -Scope It
+            }
+
+            It "Should install and import the specified version of Pester regardless of what is avaialble locally" {
+                Mock -CommandName Find-Module -MockWith { [PsCustomObject]@{Version=[version]::new(4,2,0);Repository='PSGallery'}}
+                Mock -CommandName Get-PackageProvider -MockWith { $True }
+
+                Import-Pester -Version 4.2.0
+
+                Assert-MockCalled -CommandName Install-Module -Times 1 -ParameterFilter { $RequiredVersion -eq "4.2.0"}
+                Assert-MockCalled -CommandName Import-Module -Times 1 -ParameterFilter {$RequiredVersion -eq "4.2.0"}
+            }
+
+            It "Should not Install the latest version of Pester when on PowerShellGet is available but SkipPublisherCheck is not available" {
+                Mock -CommandName Find-Module -MockWith { [PsCustomObject]@{Version=[version]::new(9,9,9);Repository='PSGallery'}}
+                Mock -CommandName Get-PackageProvider -MockWith { $True }
+                Mock -CommandName Get-Command -MockWith { [PsCustomObject]@{Parameters=@{OtherProperty='SomeValue'}} } -ParameterFilter {$Name -eq 'Install-Module'}
+
+                Import-Pester -Version "latest"
+
+                Assert-MockCalled -CommandName Install-Module -Times 0 -Scope It
+                Assert-MockCalled -CommandName Import-Module -Times 1 -ParameterFilter {$Name -like '*\4.10.1\Pester.psd1'}
+            }
+
+            It "Should fall back to build in version of Pester when no repositories are available" {
+                Mock -CommandName Get-PSRepository -MockWith {}
+                Mock -CommandName Get-Command -MockWith { [PsCustomObject]@{Parameters=@{SkipPublisherCheck='SomeValue'}}} -ParameterFilter {$Name -eq 'Install-Module'}
+
+                Import-Pester -Version "latest"
+
+                Assert-MockCalled -CommandName Install-Module -Times 0 -Scope It
+                Assert-MockCalled -CommandName Write-Host -Times 1 -Scope It -ParameterFilter {
+                    $Object -eq "##vso[task.logissue type=warning]Falling back to version of Pester shipped with extension. To use a newer version please update the version of PowerShellGet available on this machine."
+                }
+                Assert-MockCalled -CommandName Import-Module -Times 1 -ParameterFilter {$Name -like '*\4.10.1\Pester.psd1'}
+            }
+
+            <#It "Loads Pester version that ships with task when not on PS5+ or PowerShellGet is unavailable" {
+                Mock -CommandName Invoke-Pester -MockWith { }
+                Mock -CommandName Import-Module -MockWith { }
+                Mock -CommandName Write-Host -MockWith { }
+                Mock -CommandName Write-Warning -MockWith { }
+                Mock -CommandName Write-Error -MockWith { }
+                Mock -CommandName Get-Module -MockWith { }
+
+                &$sut -ScriptFolder TestDrive:\ -ResultsFile TestDrive:\output.xml
+                Assert-MockCalled  Import-Module -ParameterFilter { $Name -eq "$pwd\4.10.1\Pester.psd1" }
+                Assert-MockCalled Invoke-Pester
+            }#>
         }
-
-        <#It "Loads Pester version that ships with task when not on PS5+ or PowerShellGet is unavailable" {
-            Mock -CommandName Invoke-Pester -MockWith { }
-            Mock -CommandName Import-Module -MockWith { }
-            Mock -CommandName Write-Host -MockWith { }
-            Mock -CommandName Write-Warning -MockWith { }
-            Mock -CommandName Write-Error -MockWith { }
-            Mock -CommandName Get-Module -MockWith { }
-
-            &$sut -ScriptFolder TestDrive:\ -ResultsFile TestDrive:\output.xml
-            Assert-MockCalled  Import-Module -ParameterFilter { $Name -eq "$pwd\4.10.1\Pester.psd1" }
-            Assert-MockCalled Invoke-Pester
-        }#>
-    }
+    } 
 }

--- a/Extension/PesterTask/test/PesterTask/Helper.Tests.ps1
+++ b/Extension/PesterTask/test/PesterTask/Helper.Tests.ps1
@@ -2,7 +2,7 @@
 Describe "Testing Helper Functions" {
 
     BeforeAll {
-        Import-Module -Name (Resolve-Path "$PSScriptRoot/../../PesterV9/HelperModule.psm1") -Forc
+        Import-Module -Name (Resolve-Path "$PSScriptRoot/../../PesterV9/HelperModule.psm1") -Force
     }
     Context "Testing Get-HashtableFromString" {
 


### PR DESCRIPTION
### What problem does this PR address?
Fixes error messages being written when Powershell Gallery is not reachable from the pipeline, which causes the Pester task to fail even though the tests are executed as expected
  
### Is there a related Issue?
#18 
