### PR TITLE
Update to latest pipelines library - Fixes #32

### DIFF
--- a/Extension/PesterTask/src/agentSpecific.ts
+++ b/Extension/PesterTask/src/agentSpecific.ts
@@ -1,4 +1,4 @@
-import tl = require("vsts-task-lib/task");
+import tl = require("azure-pipelines-task-lib/task");
 import fs = require("fs");
 
 // moving the logging function to a separate file

--- a/Extension/PesterTask/src/pester.ts
+++ b/Extension/PesterTask/src/pester.ts
@@ -1,4 +1,4 @@
-import tl = require("vsts-task-lib/task");
+import tl = require("azure-pipelines-task-lib/task");
 import { basename } from "path";
 
 import {

--- a/Extension/PesterTask/src/pesterv10.ts
+++ b/Extension/PesterTask/src/pesterv10.ts
@@ -1,4 +1,4 @@
-import tl = require("vsts-task-lib/task");
+import tl = require("azure-pipelines-task-lib/task");
 import { basename } from "path";
 
 import {

--- a/Extension/package.json
+++ b/Extension/package.json
@@ -16,7 +16,7 @@
     "fs": "0.0.1-security",
     "ncp": "^2.0.0",
     "rimraf": "^2.6.2",
-    "vsts-task-lib": "^2.7.0"
+    "azure-pipelines-task-lib": "^2.9.6"
   },
   "devDependencies": {
     "@types/chai": "^4.0.4",


### PR DESCRIPTION
### What problem does this PR address?
Library for task was still using the vsts-task-lib which had some functionality deprecated in node. Upgrade to the azure-pipelines-task-lib and a newer version to fix this.
  
### Is there a related Issue?
#32
  
### Have you...
- If you are willing, please enable me, as the Repo owner, to [edit your fork that contains your PR](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) so I can add any missing items such as the readme.md
