### PR TITLE
Update import-pester function to ensure it handles the host only having v5 or higher

### DIFF
--- a/Extension/PesterTask/PesterV9/HelperModule.psm1
+++ b/Extension/PesterTask/PesterV9/HelperModule.psm1
@@ -48,7 +48,7 @@ function Import-Pester {
             if ($Version -eq "latest") {
                 $NewestPester = Find-Module -Name Pester -MaximumVersion 4.99.99 -ErrorAction Stop | Sort-Object Version -Descending | Select-Object -First 1
 
-                If ((Get-Module Pester -ListAvailable | Sort-Object Version -Descending| Select-Object -First 1).Version -lt $NewestPester.Version) {
+                If ((Get-Module Pester -ListAvailable | Where-Object Version -lt '5.0.0' | Sort-Object Version -Descending| Select-Object -First 1).Version -lt $NewestPester.Version) {
                     Install-Module -Name Pester -RequiredVersion $NewestPester.Version -Scope CurrentUser -Force -Repository $NewestPester.Repository -SkipPublisherCheck
                 }
             }


### PR DESCRIPTION
### What problem does this PR address?
If the host has only v5 or higher versions of Pester and the v9 task is being used then it won't download the v4.x version of pester.
  
### Is there a related Issue?
#42 
  
### Have you...
- If you are willing, please enable me, as the Repo owner, to [edit your fork that contains your PR](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) so I can add any missing items such as the readme.md
