### PR TITLE
Add support for file paths being provided for the pre-test scriptblock

### DIFF
--- a/Extension/PesterTask/PesterV10/Pester.ps1
+++ b/Extension/PesterTask/PesterV10/Pester.ps1
@@ -131,6 +131,9 @@ if ($CodeCoverageOutputFile) {
 }
 
 if (-not([String]::IsNullOrWhiteSpace($ScriptBlock))) {
+    if (Test-Path $ScriptBlock) {
+        $ScriptBlock = Get-Content -Path $ScriptBlock -Raw
+    }
     $ScriptBlockObject = [ScriptBlock]::Create($ScriptBlock)
 
     $ScriptBlockObject.Invoke()

--- a/Extension/PesterTask/PesterV9/Pester.ps1
+++ b/Extension/PesterTask/PesterV9/Pester.ps1
@@ -134,6 +134,9 @@ elseif ($CodeCoverageOutputFile -and (Get-Module Pester).Version -lt [Version]::
 }
 
 if (-not([String]::IsNullOrWhiteSpace($ScriptBlock))) {
+    if (Test-Path $ScriptBlock) {
+        $ScriptBlock = Get-Content -Path $ScriptBlock -Raw
+    }
     $ScriptBlockObject = [ScriptBlock]::Create($ScriptBlock)
 
     $ScriptBlockObject.Invoke()


### PR DESCRIPTION
### What problem does this PR address?
If a user provides a path to a script file for the pre-test scriptblock parameter then nothing will be executed. This resolves that by getting the script contents and then creating a scriptblock from it.
  
### Is there a related Issue?
#31 
  
### Have you...
- If you are willing, please enable me, as the Repo owner, to [edit your fork that contains your PR](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) so I can add any missing items such as the readme.md
