### PR TITLE
Pester issue #1650 - xplatform path separator for additional module path

### DIFF
--- a/Extension/PesterTask/PesterV10/Pester.ps1
+++ b/Extension/PesterTask/PesterV10/Pester.ps1
@@ -84,7 +84,7 @@ Write-Host "Running in $($env:Processor_Architecture) PowerShell"
 
 if ($PSBoundParameters.ContainsKey('additionalModulePath')) {
     Write-Host "Adding additional module path [$additionalModulePath] to `$env:PSModulePath"
-    $env:PSModulePath = $additionalModulePath + ';' + $env:PSModulePath
+    $env:PSModulePath = $additionalModulePath + [System.IO.Path]::PathSeparator + $env:PSModulePath
 }
 $PesterConfig = [PesterConfiguration]::Default
 


### PR DESCRIPTION
### What problem does this PR address?
Can't test PS module (additional module path) on a Linux build box.
  
### Is there a related Issue?
https://github.com/pester/Pester/issues/1650
