### PR TITLE
Enable TLS1.2 and 1.3 to allow greater security by default - fixes #54

### DIFF
--- a/Extension/PesterTask/PesterV10/Pester.ps1
+++ b/Extension/PesterTask/PesterV10/Pester.ps1
@@ -61,6 +61,9 @@ Write-Host "ScriptBlock $ScriptBlock"
 Import-Module -Name (Join-Path $PSScriptRoot "HelperModule.psm1") -Force
 Import-Pester -Version $TargetPesterVersion
 
+# Enable use of TLS 1.2 and 1.3 along with whatever else is already enabled. If tests need to override it then they can do so within them or what they are testing.
+[Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12 -bor [Net.SecurityProtocolType]::Tls13
+
 if ($run32Bit -eq $true -and $env:Processor_Architecture -ne "x86") {
     Write-Warning "32bit support is considered deprecated in this version of the task and will be removed in a future major version."
     # Get the command parameters

--- a/Extension/PesterTask/PesterV9/Pester.ps1
+++ b/Extension/PesterTask/PesterV9/Pester.ps1
@@ -60,6 +60,9 @@ Write-Host "ScriptBlock $ScriptBlock"
 Import-Module -Name (Join-Path $PSScriptRoot "HelperModule.psm1") -Force
 Import-Pester -Version $TargetPesterVersion
 
+# Enable use of TLS 1.2 and 1.3 along with whatever else is already enabled. If tests need to override it then they can do so within them or what they are testing.
+[Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12 -bor [Net.SecurityProtocolType]::Tls13
+
 if ($run32Bit -eq $true -and $env:Processor_Architecture -ne "x86") {
     # Get the command parameters
     $args = $myinvocation.BoundParameters.GetEnumerator() | ForEach-Object {


### PR DESCRIPTION
### What problem does this PR address?
TLS on Azure Pipelines agents could be set to lower than 1.2 as it's set at the OS level by default. Enabling 1.2 and 1.3 as additional protocols gives us greater security options. If tests require these to be disabled then they should explicitly specifying that. Using `-bor` ensure anything already enabled is not overwritten.
  
### Is there a related Issue?
#54 
  
### Have you...
- If you are willing, please enable me, as the Repo owner, to [edit your fork that contains your PR](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) so I can add any missing items such as the readme.md
