### PR TITLE
Add flag to fail on or not on stderr - Fixes #56

### DIFF
--- a/Extension/PesterTask/PesterV10/task.json
+++ b/Extension/PesterTask/PesterV10/task.json
@@ -145,6 +145,13 @@
       "required": false,
       "helpMarkDown": "A scriptblock to run before tests are executed. This will be run in the scope of the task where Invoke-Pester is run.",
       "groupName": "advanced"
+    },
+    {
+      "name": "failOnStdErr",
+      "type": "boolean",
+      "defaultValue": true,
+      "label": "Fail on StdErr",
+      "helpMarkDown": "Sets whether the task should fail on any output to StdErr from within the tests or not. Default true"
     }
    ],
   "instanceNameFormat": "Pester Test Runner",

--- a/Extension/PesterTask/PesterV9/task.json
+++ b/Extension/PesterTask/PesterV9/task.json
@@ -142,6 +142,13 @@
       "required": false,
       "helpMarkDown": "A scriptblock to run before tests are executed. This will be run in the scope of the task where Invoke-Pester is run.",
       "groupName": "advanced"
+    },
+    {
+      "name": "failOnStdErr",
+      "type": "boolean",
+      "defaultValue": true,
+      "label": "Fail on StdErr",
+      "helpMarkDown": "Sets whether the task should fail on any output to StdErr from within the tests or not. Default true"
     }
    ],
   "instanceNameFormat": "Pester Test Runner",

--- a/Extension/PesterTask/src/pester.ts
+++ b/Extension/PesterTask/src/pester.ts
@@ -20,6 +20,7 @@ export async function run() {
         let CodeCoverageFolder = tl.getInput("CodeCoverageFolder");
         let ScriptBlock = tl.getInput("ScriptBlock");
         let PesterVersion = tl.getInput("PesterVersion");
+        let FailOnStdErr = tl.getInput("failOnStdErr");
 
         let TargetPesterVersion = "0.0.0";
         if (PesterVersion === "OtherVersion") {
@@ -48,6 +49,7 @@ export async function run() {
                     "-scriptFolder", scriptFolder,
                     "-resultsFile", resultsFile,
                     "-run32Bit", run32Bit,
+                    "-FailOnStdErr", FailOnStdErr,
                 ];
 
         if (additionalModulePath) {

--- a/Extension/PesterTask/src/pesterv10.ts
+++ b/Extension/PesterTask/src/pesterv10.ts
@@ -20,6 +20,7 @@ export async function run() {
         let CodeCoverageFolder = tl.getInput("CodeCoverageFolder");
         let ScriptBlock = tl.getInput("ScriptBlock");
         let PesterVersion = tl.getInput("PesterVersion");
+        let FailOnStdErr = tl.getInput("failOnStdErr");
 
         let TargetPesterVersion = "0.0.0";
         if (PesterVersion === "OtherVersion") {
@@ -48,6 +49,7 @@ export async function run() {
                     "-TestFolder", TestFolder,
                     "-resultsFile", resultsFile,
                     "-run32Bit", run32Bit,
+                    "-FailOnStdErr", FailOnStdErr,
                 ];
 
         if (additionalModulePath) {


### PR DESCRIPTION
### What problem does this PR address?
If a tested function or application write to StdErr and it is not captured then it can cause the task to fail even if it's actually succeeded. This is usually an issue with command line tools (like git) where they will often write information output to stderr  because they are limited to 2 streams of data. 

The solution here is to add a flag to allow the user to decide if the task should fail when data is written to StdErr. It currently defaults to True as that is the current behaviour and I don't want to break it for anyone who is currently using this behaviour as they'd expect. The test suite will still fail correctly if any tests fail as those are tracked separately by Pester and the logs don't write to StdErr (using Write-Host instead).
  
### Is there a related Issue?
#56
  
### Have you...
- If you are willing, please enable me, as the Repo owner, to [edit your fork that contains your PR](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) so I can add any missing items such as the readme.md
