### PR TITLE
Fixes #63: __dirname must be quoted to support paths with spaces.

### DIFF
--- a/Extension/PesterTask/src/pester.ts
+++ b/Extension/PesterTask/src/pester.ts
@@ -45,7 +45,7 @@ export async function run() {
         }
 
         // we need to not pass the null param
-        var args = [__dirname + "\\Pester.ps1",
+        var args = ['"' + __dirname + "\\Pester.ps1" + '"',
                     "-scriptFolder", scriptFolder,
                     "-resultsFile", resultsFile,
                     "-run32Bit", run32Bit,

--- a/Extension/PesterTask/src/pester.ts
+++ b/Extension/PesterTask/src/pester.ts
@@ -45,7 +45,7 @@ export async function run() {
         }
 
         // we need to not pass the null param
-        var args = ['"' + __dirname + "\\Pester.ps1" + '"',
+        var args = ['"' + __dirname + "/Pester.ps1" + '"',
                     "-scriptFolder", scriptFolder,
                     "-resultsFile", resultsFile,
                     "-run32Bit", run32Bit,

--- a/Extension/PesterTask/src/pester.ts
+++ b/Extension/PesterTask/src/pester.ts
@@ -45,7 +45,7 @@ export async function run() {
         }
 
         // we need to not pass the null param
-        var args = ['"' + __dirname + "\\Pester.ps1" + '"',
+        var args = [__dirname + "\\Pester.ps1",
                     "-scriptFolder", scriptFolder,
                     "-resultsFile", resultsFile,
                     "-run32Bit", run32Bit,
@@ -94,7 +94,7 @@ export async function run() {
         logInfo(`${executable} ${args.join(" ")}`);
 
         var spawn = require("child_process").spawn, child;
-        child = spawn(executable, args, {windowsVerbatimArguments: true});
+        child = spawn(executable, args);
         child.stdout.on("data", function (data) {
             logInfo(data.toString());
         });

--- a/Extension/PesterTask/src/pesterv10.ts
+++ b/Extension/PesterTask/src/pesterv10.ts
@@ -45,7 +45,7 @@ export async function run() {
         }
 
         // we need to not pass the null param
-        var args = [__dirname + "\\Pester.ps1",
+        var args = ['"' + __dirname + "\\Pester.ps1" + '"',
                     "-TestFolder", TestFolder,
                     "-resultsFile", resultsFile,
                     "-run32Bit", run32Bit,

--- a/Extension/PesterTask/src/pesterv10.ts
+++ b/Extension/PesterTask/src/pesterv10.ts
@@ -45,7 +45,7 @@ export async function run() {
         }
 
         // we need to not pass the null param
-        var args = ['"' + __dirname + "\\Pester.ps1" + '"',
+        var args = ['"' + __dirname + "/Pester.ps1" + '"',
                     "-TestFolder", TestFolder,
                     "-resultsFile", resultsFile,
                     "-run32Bit", run32Bit,

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -81,6 +81,8 @@ stages:
     jobs:
       - deployment: validate
         displayName: Validate publish
+        pool:
+          vmImage: windows-latest
         environment: pester
         strategy:
           runOnce:


### PR DESCRIPTION
### What problem does this PR address?
This addresses #63, when an agent is installed in a directory with spaces. (Eg. `C:\Program Files`.)
  
### Is there a related Issue?
This is intended to fix #63.

### Other notes
It looks like `spawn()` would normally take care of this itself except that we have `windowsVerbatimArguments: true`, which keeps spawn() from quoting its arguments.